### PR TITLE
refactor: decompose main, blame improvements, and minor perf wins

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -88,7 +88,7 @@ strata/
 
 5. **Blob deduplication** (`main.rs`) — Group work items by blob OID. If the same file content appears in 50 sampled commits, it only needs one blame call. The dedup ratio is logged at `-v`.
 
-6. **Parallel blame** (`blame.rs`) — A dedicated Rayon pool (size controlled by `--jobs`, default 8 — see [why](#parallel-blame-thread-pool)) runs blame for each unique blob. Each thread checks the sled cache first; on a miss it spawns `git blame --porcelain` and stores the result.
+6. **Parallel blame** (`blame.rs`) — A dedicated Rayon pool (size controlled by `--jobs`, default 8 — see [why](#parallel-blame-thread-pool)) runs blame for each unique blob. Each thread checks the sled cache first; on a miss it spawns `git blame --porcelain -w` (plus `--ignore-revs-file` if `.git-blame-ignore-revs` exists in the repo root) and stores the result.
 
 7. **Aggregation** (`main.rs`) — Two passes:
    - **Per-blob histogram**: for each blob, count lines per period key and per author. Run in parallel.
@@ -118,7 +118,7 @@ Entry point and orchestration. Owns:
 
 Two public functions:
 
-**`spawn_blame(repo_path, commit_oid, file_path)`** — Spawns `git blame --porcelain <commit> -- <file>` as a subprocess with `GIT_CONFIG_NOSYSTEM=1`, `GIT_CONFIG_GLOBAL=/dev/null`, and `GIT_OPTIONAL_LOCKS=0` to eliminate per-process config-file overhead across thousands of concurrent invocations.
+**`spawn_blame(repo_path, commit_oid, file_path, ignore_revs)`** — Spawns `git blame --porcelain -w <commit> -- <file>` as a subprocess with `GIT_CONFIG_NOSYSTEM=1`, `GIT_CONFIG_GLOBAL=/dev/null`, and `GIT_OPTIONAL_LOCKS=0` to eliminate per-process config-file overhead across thousands of concurrent invocations. `-w` is always passed so whitespace-only changes don't shift attribution. If `ignore_revs` is `Some(path)`, `--ignore-revs-file=<path>` is appended to skip bulk commits (e.g. formatting runs) from attribution.
 
 **`parse_blame_output(stdout, blob_oid, cache)`** — Parses the porcelain format line by line. Commit metadata (author name, author-time) appears once per commit in the output; subsequent lines for the same commit reference the cached values. Emits one `(timestamp, author)` pair per source line. Stores the result in sled keyed by blob OID before returning.
 
@@ -192,6 +192,8 @@ pub struct Tag {
 
 libgit2's `blame_file()` is roughly 100× slower than the system `git blame` binary for the same file. strata shells out to `git` for all blame work. The subprocess environment is stripped to the minimum (`GIT_CONFIG_NOSYSTEM`, `GIT_CONFIG_GLOBAL=/dev/null`, `GIT_OPTIONAL_LOCKS=0`) to shave config-reading overhead across thousands of concurrent invocations.
 
+`-w` is always passed so whitespace-only reformatting commits don't shift authorship credit. If the repo root contains a `.git-blame-ignore-revs` file, `--ignore-revs-file` is passed automatically — `GIT_CONFIG_GLOBAL=/dev/null` would otherwise suppress any config-based `blame.ignoreRevsFile`, so strata detects the file itself and injects the flag directly.
+
 libgit2 is still used for everything else — commit walking, tree walking, SSH credential handling — where it's fast and convenient.
 
 ### Parallel blame thread pool
@@ -212,6 +214,8 @@ Blame results are stored in a [sled](https://github.com/spacejam/sled) embedded 
 - **Content-addressed** — renaming or moving a file doesn't invalidate its entry
 
 Cache entries are serialised with [bincode](https://github.com/bincode-org/bincode) as `Vec<(i64, String)>` (timestamp, author name).
+
+> **Upgrade note:** `-w` changes which commit git attributes each line to, so cache entries produced by older versions of strata (without `-w`) will return stale results. Run with `--no-cache` once after upgrading to force a clean recompute.
 
 ### Two-pass aggregation
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -205,11 +205,17 @@ Cache entries are keyed by blob OID (the SHA of the file content), so:
 - Entries survive across runs and across different repositories.
 - Moving or renaming a file doesn't invalidate its cache entry as long as the content didn't change.
 
-To force a fresh run (e.g. after suspecting a corrupted entry):
+To force a fresh run (e.g. after suspecting a corrupted entry, or after upgrading strata — see note below):
 
 ```sh
 strata process -r /path/to/repo --no-cache
 ```
+
+> **After upgrading:** strata now always passes `-w` to `git blame`, which changes line attribution for commits that only touch whitespace. Existing cache entries were produced without `-w` and will give different results than a fresh run. Pass `--no-cache` once after upgrading to recompute cleanly.
+
+### `.git-blame-ignore-revs`
+
+If the repository contains a `.git-blame-ignore-revs` file in its root, strata automatically passes it to every `git blame` invocation via `--ignore-revs-file`. This causes bulk commits (formatting runs, mass renames) to be skipped, so lines are attributed to the author who made the meaningful change rather than whoever ran the formatter. No configuration is needed — the file's presence is the signal.
 
 You can delete the entire cache directory to reclaim disk space at any time:
 

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -33,7 +33,7 @@ pub fn spawn_blame(
         .ok()
 }
 
-pub fn parse_blame_output(stdout: &[u8], blob_oid: Oid, cache: &sled::Db) -> Vec<(i64, String)> {
+pub fn parse_blame_output(stdout: &[u8]) -> Vec<(i64, String)> {
     // Parse --porcelain: commit metadata appears once per commit, keyed by the 40-char sha
     // that starts each hunk header. "author" and "author-time" lines are cached per sha;
     // "\t" lines emit one (timestamp, author) pair.
@@ -69,8 +69,5 @@ pub fn parse_blame_output(stdout: &[u8], blob_oid: Oid, cache: &sled::Db) -> Vec
         }
     }
 
-    if let Ok(encoded) = bincode::serialize(&lines) {
-        let _ = cache.insert(blob_oid.as_bytes(), encoded.as_slice());
-    }
     lines
 }

--- a/src/blame.rs
+++ b/src/blame.rs
@@ -15,22 +15,26 @@ pub fn spawn_blame(
     repo_path: &Path,
     commit_oid: Oid,
     file_path: &str,
+    ignore_revs: Option<&Path>,
 ) -> Option<std::process::Child> {
-    std::process::Command::new("git")
-        .args([
-            "-C", &repo_path.to_string_lossy(),
-            "blame", "--porcelain",
-            &commit_oid.to_string(),
-            "--", file_path,
-        ])
-        .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env("GIT_CONFIG_GLOBAL", if cfg!(windows) { "NUL" } else { "/dev/null" })
-        .env("GIT_OPTIONAL_LOCKS", "0")
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .spawn()
-        .map_err(|e| warn!("git spawn failed for {file_path}: {e}"))
-        .ok()
+    let mut cmd = std::process::Command::new("git");
+    cmd.args([
+        "-C", &repo_path.to_string_lossy(),
+        "blame", "--porcelain", "-w",
+        &commit_oid.to_string(),
+        "--", file_path,
+    ]);
+    if let Some(p) = ignore_revs {
+        cmd.arg(format!("--ignore-revs-file={}", p.display()));
+    }
+    cmd.env("GIT_CONFIG_NOSYSTEM", "1")
+       .env("GIT_CONFIG_GLOBAL", if cfg!(windows) { "NUL" } else { "/dev/null" })
+       .env("GIT_OPTIONAL_LOCKS", "0")
+       .stdout(std::process::Stdio::piped())
+       .stderr(std::process::Stdio::null())
+       .spawn()
+       .map_err(|e| warn!("git spawn failed for {file_path}: {e}"))
+       .ok()
 }
 
 pub fn parse_blame_output(stdout: &[u8]) -> Vec<(i64, String)> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,19 +7,23 @@ mod types;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
-use git2::Repository;
+use git2::{Oid, Repository};
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::{debug, info};
 use tracing_subscriber::{fmt, EnvFilter};
 
 use blame::{parse_blame_output, spawn_blame};
 use period::{get_version_tags, period_int_to_string, ts_to_period_int};
 use repo::{collect_work_items, ensure_repo, get_commit_list, repo_name, sample_commits};
-use types::{OutputData, SeriesPoint};
+use types::{OutputData, SeriesPoint, WorkItem};
+
+type BlobHists = FxHashMap<Oid, (FxHashMap<i32, u64>, FxHashMap<String, u64>)>;
+type PeriodAgg = FxHashMap<(Oid, i32), u64>;
+type AuthorAgg = FxHashMap<(Oid, String), u64>;
 
 #[derive(Parser, Debug)]
 #[command(name = "strata", about = "Git code archaeology — fast parallel blame aggregator")]
@@ -30,6 +34,14 @@ struct Cli {
 
     #[command(subcommand)]
     command: Command,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Analyze repositories and write data files
+    Process(ProcessArgs),
+    /// Serve the web UI with embedded assets
+    Serve(ServeArgs),
 }
 
 #[derive(clap::ValueEnum, Debug, Clone, PartialEq)]
@@ -45,14 +57,6 @@ impl std::fmt::Display for Granularity {
             Granularity::Year => write!(f, "year"),
         }
     }
-}
-
-#[derive(Subcommand, Debug)]
-enum Command {
-    /// Analyze repositories and write data files
-    Process(ProcessArgs),
-    /// Serve the web UI with embedded assets
-    Serve(ServeArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -133,6 +137,192 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+fn build_blame_pool(jobs: usize) -> Result<rayon::ThreadPool> {
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(jobs)
+        .build()
+        .context("failed to create blame thread pool")
+}
+
+fn run_blame_phase(
+    blame_lookup: &FxHashMap<Oid, (Oid, String)>,
+    repo_path: &Path,
+    no_cache: bool,
+    cache: &sled::Db,
+    pool: &rayon::ThreadPool,
+    pb: &ProgressBar,
+    yearly: bool,
+) -> (BlobHists, u64) {
+    let cache_hits = std::sync::atomic::AtomicU64::new(0);
+    let blob_hists = pool.install(|| {
+        blame_lookup
+            .par_iter()
+            .map(|(&blob_oid, (commit_oid, file_path))| {
+                let lines = if !no_cache {
+                    cache
+                        .get(blob_oid.as_bytes())
+                        .ok()
+                        .flatten()
+                        .and_then(|v| bincode::deserialize::<Vec<(i64, String)>>(&v).ok())
+                        .inspect(|_| {
+                            cache_hits.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        })
+                } else {
+                    None
+                }
+                .unwrap_or_else(|| {
+                    let lines = spawn_blame(repo_path, *commit_oid, file_path)
+                        .and_then(|child| child.wait_with_output().ok())
+                        .filter(|o| o.status.success())
+                        .map(|o| parse_blame_output(&o.stdout))
+                        .unwrap_or_default();
+                    if let Ok(encoded) = bincode::serialize(&lines) {
+                        let _ = cache.insert(blob_oid.as_bytes(), encoded.as_slice());
+                    }
+                    lines
+                });
+                pb.inc(1);
+                let mut period_hist: FxHashMap<i32, u64> = FxHashMap::default();
+                let mut author_hist: FxHashMap<String, u64> = FxHashMap::default();
+                for (lts, author) in lines {
+                    *period_hist.entry(ts_to_period_int(lts, yearly)).or_insert(0) += 1;
+                    *author_hist.entry(author).or_insert(0) += 1;
+                }
+                (blob_oid, (period_hist, author_hist))
+            })
+            .collect()
+    });
+    let hits = cache_hits.load(std::sync::atomic::Ordering::Relaxed);
+    (blob_hists, hits)
+}
+
+fn aggregate(items: &[WorkItem], blob_hists: &BlobHists) -> (PeriodAgg, AuthorAgg) {
+    let mut agg: PeriodAgg = FxHashMap::default();
+    let mut author_agg: AuthorAgg = FxHashMap::default();
+    for item in items {
+        let Some((period_hist, author_hist)) = blob_hists.get(&item.blob_oid) else { continue };
+        for (&period, &count) in period_hist {
+            *agg.entry((item.commit_oid, period)).or_insert(0) += count;
+        }
+        for (author, &count) in author_hist {
+            *author_agg.entry((item.commit_oid, author.clone())).or_insert(0) += count;
+        }
+    }
+    (agg, author_agg)
+}
+
+fn select_authors(
+    author_agg: &AuthorAgg,
+    sampled: &[(Oid, i64)],
+    threshold: f64,
+) -> (Vec<String>, bool, FxHashMap<Oid, u64>) {
+    let active_authors: Vec<String> = if let Some(&(last_oid, _)) = sampled.last() {
+        let mut head_counts: Vec<(String, u64)> = author_agg
+            .iter()
+            .filter(|((oid, _), _)| *oid == last_oid)
+            .map(|((_, author), &count)| (author.clone(), count))
+            .collect();
+        head_counts.sort_by(|a, b| b.1.cmp(&a.1));
+        let total: u64 = head_counts.iter().map(|(_, c)| c).sum();
+        let target = (total as f64 * threshold) as u64;
+        let mut cumulative = 0u64;
+        let mut active = Vec::new();
+        for (author, count) in head_counts {
+            active.push(author);
+            cumulative += count;
+            if cumulative >= target {
+                break;
+            }
+        }
+        active
+    } else {
+        Vec::new()
+    };
+
+    let active_author_set: FxHashSet<String> = active_authors.iter().cloned().collect();
+    let has_other = sampled.last().is_some_and(|&(last_oid, _)| {
+        author_agg.keys().any(|(oid, a)| *oid == last_oid && !active_author_set.contains(a))
+    });
+
+    let mut commit_other: FxHashMap<Oid, u64> = FxHashMap::default();
+    if has_other {
+        for ((oid, author), &count) in author_agg {
+            if !active_author_set.contains(author) {
+                *commit_other.entry(*oid).or_insert(0) += count;
+            }
+        }
+    }
+
+    (active_authors, has_other, commit_other)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_series(
+    sampled: &[(Oid, i64)],
+    agg: &PeriodAgg,
+    author_agg: &AuthorAgg,
+    active_authors: &[String],
+    has_other: bool,
+    commit_other: &FxHashMap<Oid, u64>,
+    all_period_ints: &[i32],
+    repo: &Repository,
+) -> Vec<SeriesPoint> {
+    sampled
+        .iter()
+        .map(|&(oid, ts)| {
+            let (summary, author) = repo
+                .find_commit(oid)
+                .ok()
+                .map(|c| (
+                    c.summary().unwrap_or("").to_string(),
+                    c.author().name().unwrap_or("unknown").to_string(),
+                ))
+                .unwrap_or_default();
+            let counts: Vec<(usize, u64)> = all_period_ints
+                .iter()
+                .enumerate()
+                .filter_map(|(i, &p)| {
+                    let c = agg.get(&(oid, p)).copied().unwrap_or(0);
+                    if c > 0 { Some((i, c)) } else { None }
+                })
+                .collect();
+            let total: u64 = counts.iter().map(|(_, c)| c).sum();
+            let mut author_counts: Vec<(usize, u64)> = active_authors
+                .iter()
+                .enumerate()
+                .filter_map(|(i, a)| {
+                    let c = author_agg.get(&(oid, a.clone())).copied().unwrap_or(0);
+                    if c > 0 { Some((i, c)) } else { None }
+                })
+                .collect();
+            if has_other {
+                let c = commit_other.get(&oid).copied().unwrap_or(0);
+                if c > 0 { author_counts.push((active_authors.len(), c)); }
+            }
+            SeriesPoint { ts, total, counts, author_counts, summary, author }
+        })
+        .collect()
+}
+
+fn write_output(output: &OutputData, output_dir: &Path, name: &str) -> Result<()> {
+    let out_path = output_dir.join(format!("{name}.msgpack"));
+    fs::write(&out_path, rmp_serde::to_vec_named(output)?)?;
+    info!("Written {}", out_path.display());
+
+    let repos_path = output_dir.join("repos.json");
+    let mut repos: Vec<String> = if repos_path.exists() {
+        serde_json::from_str(&fs::read_to_string(&repos_path)?).unwrap_or_default()
+    } else {
+        Vec::new()
+    };
+    if !repos.iter().any(|r| r == name) {
+        repos.push(name.to_string());
+        repos.sort();
+        fs::write(&repos_path, serde_json::to_string_pretty(&repos)?)?;
+    }
+    Ok(())
+}
+
 async fn run_process(args: ProcessArgs) -> Result<()> {
 
     #[cfg(feature = "profiling")]
@@ -189,60 +379,15 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
             .progress_chars("━━╾─"),
     );
 
-    let no_cache = args.no_cache;
-    let cache_hits = std::sync::atomic::AtomicU64::new(0);
     let yearly = args.granularity == Granularity::Year;
-
-    // Dedicated rayon pool sized for subprocess-bound work (not CPU-bound),
-    // so we can saturate I/O without starving the global pool.
-    let blame_pool = rayon::ThreadPoolBuilder::new()
-        .num_threads(args.jobs)
-        .build()
-        .context("failed to create blame thread pool")?;
+    let blame_pool = build_blame_pool(args.jobs)?;
 
     // Blame each unique blob and aggregate to histograms inline — raw lines are
     // dropped as each closure returns, so we never hold all blame output in memory.
-    let blob_hists: FxHashMap<_, (FxHashMap<i32, u64>, FxHashMap<String, u64>)> =
-        blame_pool.install(|| {
-            blame_lookup
-                .par_iter()
-                .map(|(&blob_oid, (commit_oid, file_path))| {
-                    let lines = if !no_cache {
-                        cache
-                            .get(blob_oid.as_bytes())
-                            .ok()
-                            .flatten()
-                            .and_then(|v| bincode::deserialize::<Vec<(i64, String)>>(&v).ok())
-                            .inspect(|_| {
-                                cache_hits.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                            })
-                    } else {
-                        None
-                    }
-                    .unwrap_or_else(|| {
-                        let lines = spawn_blame(&repo_path, *commit_oid, file_path)
-                            .and_then(|child| child.wait_with_output().ok())
-                            .filter(|o| o.status.success())
-                            .map(|o| parse_blame_output(&o.stdout))
-                            .unwrap_or_default();
-                        if let Ok(encoded) = bincode::serialize(&lines) {
-                            let _ = cache.insert(blob_oid.as_bytes(), encoded.as_slice());
-                        }
-                        lines
-                    });
-                    pb.inc(1);
-                    let mut period_hist: FxHashMap<i32, u64> = FxHashMap::default();
-                    let mut author_hist: FxHashMap<String, u64> = FxHashMap::default();
-                    for (lts, author) in lines {
-                        *period_hist.entry(ts_to_period_int(lts, yearly)).or_insert(0) += 1;
-                        *author_hist.entry(author).or_insert(0) += 1;
-                    }
-                    (blob_oid, (period_hist, author_hist))
-                })
-                .collect()
-        });
+    let (blob_hists, hits) = run_blame_phase(
+        &blame_lookup, &repo_path, args.no_cache, &cache, &blame_pool, &pb, yearly,
+    );
 
-    let hits = cache_hits.load(std::sync::atomic::Ordering::Relaxed);
     pb.finish_and_clear();
     info!(
         "Blame complete  ({hits}/{unique_count} cache hits, {:.0}%)",
@@ -252,17 +397,7 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
 
     // Fan out: for each work item, add the blob's histogram counts: O(items × periods)
     // Keying by OID (not ts) prevents same-second commits from inflating a single bucket.
-    let mut agg: FxHashMap<(_, i32), u64> = FxHashMap::default();
-    let mut author_agg: FxHashMap<(_, String), u64> = FxHashMap::default();
-    for item in &items {
-        let Some((period_hist, author_hist)) = blob_hists.get(&item.blob_oid) else { continue };
-        for (&period, &count) in period_hist {
-            *agg.entry((item.commit_oid, period)).or_insert(0) += count;
-        }
-        for (author, &count) in author_hist {
-            *author_agg.entry((item.commit_oid, author.clone())).or_insert(0) += count;
-        }
-    }
+    let (agg, author_agg) = aggregate(&items, &blob_hists);
     drop(items);
     drop(blob_hists);
 
@@ -284,37 +419,9 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
         all_periods.last().unwrap_or(&String::new())
     );
 
-    // Find the smallest set of top authors covering ≥ threshold% of lines at HEAD,
-    // then bucket the rest as "other".
-    let active_authors: Vec<String> = if let Some(&(last_oid, _)) = sampled.last() {
-        let mut head_counts: Vec<(String, u64)> = author_agg
-            .iter()
-            .filter(|((oid, _), _)| *oid == last_oid)
-            .map(|((_, author), &count)| (author.clone(), count))
-            .collect();
-        head_counts.sort_by(|a, b| b.1.cmp(&a.1));
-        let total: u64 = head_counts.iter().map(|(_, c)| c).sum();
-        let target = (total as f64 * args.author_threshold) as u64;
-        let mut cumulative = 0u64;
-        let mut active = Vec::new();
-        for (author, count) in head_counts {
-            active.push(author);
-            cumulative += count;
-            if cumulative >= target {
-                break;
-            }
-        }
-        active
-    } else {
-        Vec::new()
-    };
+    let (active_authors, has_other, commit_other) =
+        select_authors(&author_agg, &sampled, args.author_threshold);
     debug!("{} active authors (threshold {:.0}%)", active_authors.len(), args.author_threshold * 100.0);
-
-    let active_author_set: FxHashSet<String> = active_authors.iter().cloned().collect();
-
-    let has_other = sampled.last().map_or(false, |&(last_oid, _)| {
-        author_agg.keys().any(|(oid, a)| *oid == last_oid && !active_author_set.contains(a))
-    });
 
     let all_authors: Vec<String> = {
         let mut v = active_authors.clone();
@@ -322,51 +429,11 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
         v
     };
 
-    let mut commit_other: FxHashMap<_, u64> = FxHashMap::default();
-    if has_other {
-        for ((oid, author), &count) in &author_agg {
-            if !active_author_set.contains(author) {
-                *commit_other.entry(*oid).or_insert(0) += count;
-            }
-        }
-    }
-
     let repo_for_meta = Repository::open(&repo_path)?;
-    let series: Vec<SeriesPoint> = sampled
-        .iter()
-        .map(|&(oid, ts)| {
-            let (summary, author) = repo_for_meta
-                .find_commit(oid)
-                .ok()
-                .map(|c| (
-                    c.summary().unwrap_or("").to_string(),
-                    c.author().name().unwrap_or("unknown").to_string(),
-                ))
-                .unwrap_or_default();
-            let counts: Vec<(usize, u64)> = all_period_ints
-                .iter()
-                .enumerate()
-                .filter_map(|(i, &p)| {
-                    let c = agg.get(&(oid, p)).copied().unwrap_or(0);
-                    if c > 0 { Some((i, c)) } else { None }
-                })
-                .collect();
-            let total: u64 = counts.iter().map(|(_, c)| c).sum();
-            let mut author_counts: Vec<(usize, u64)> = active_authors
-                .iter()
-                .enumerate()
-                .filter_map(|(i, a)| {
-                    let c = author_agg.get(&(oid, a.clone())).copied().unwrap_or(0);
-                    if c > 0 { Some((i, c)) } else { None }
-                })
-                .collect();
-            if has_other {
-                let c = commit_other.get(&oid).copied().unwrap_or(0);
-                if c > 0 { author_counts.push((active_authors.len(), c)); }
-            }
-            SeriesPoint { ts, total, counts, author_counts, summary, author }
-        })
-        .collect();
+    let series = build_series(
+        &sampled, &agg, &author_agg, &active_authors, has_other,
+        &commit_other, &all_period_ints, &repo_for_meta,
+    );
 
     let tags = get_version_tags(&repo_path).unwrap_or_default();
 
@@ -391,21 +458,7 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
         tags,
     };
 
-    let out_path = args.output_dir.join(format!("{name}.msgpack"));
-    fs::write(&out_path, rmp_serde::to_vec_named(&output)?)?;
-    info!("Written {}", out_path.display());
-
-    let repos_path = args.output_dir.join("repos.json");
-    let mut repos: Vec<String> = if repos_path.exists() {
-        serde_json::from_str(&fs::read_to_string(&repos_path)?).unwrap_or_default()
-    } else {
-        Vec::new()
-    };
-    if !repos.contains(&name) {
-        repos.push(name);
-        repos.sort();
-        fs::write(&repos_path, serde_json::to_string_pretty(&repos)?)?;
-    }
+    write_output(&output, &args.output_dir, &name)?;
 
     #[cfg(feature = "profiling")]
     if let Ok(report) = _guard.report().build() {
@@ -414,8 +467,6 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
         let file = std::fs::File::create("flamegraph.svg")?;
         report.flamegraph(file)?;
 
-        // Collapsed stacks: each line is "a;b;c <count>", readable by inferno/flamegraph tools
-        // and grep-able for specific functions.
         let mut folded = std::io::BufWriter::new(std::fs::File::create("profile.folded")?);
         let mut tally: FxHashMap<String, isize> = FxHashMap::default();
         for (frames, count) in &report.data {

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,7 @@ fn run_blame_phase(
     pool: &rayon::ThreadPool,
     pb: &ProgressBar,
     yearly: bool,
+    ignore_revs: Option<&Path>,
 ) -> (BlobHists, u64) {
     let cache_hits = std::sync::atomic::AtomicU64::new(0);
     let blob_hists = pool.install(|| {
@@ -171,7 +172,7 @@ fn run_blame_phase(
                     None
                 }
                 .unwrap_or_else(|| {
-                    let lines = spawn_blame(repo_path, *commit_oid, file_path)
+                    let lines = spawn_blame(repo_path, *commit_oid, file_path, ignore_revs)
                         .and_then(|child| child.wait_with_output().ok())
                         .filter(|o| o.status.success())
                         .map(|o| parse_blame_output(&o.stdout))
@@ -355,6 +356,16 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
     let repo_path = ensure_repo(&args.repo, args.ssh_key)?;
     let name = repo_name(&args.repo);
 
+    let ignore_revs_file = {
+        let candidate = repo_path.join(".git-blame-ignore-revs");
+        if candidate.is_file() {
+            info!("using .git-blame-ignore-revs at {}", candidate.display());
+            Some(candidate)
+        } else {
+            None
+        }
+    };
+
     info!("Walking commit history");
     let all_commits = get_commit_list(&repo_path)?;
     let sampled = sample_commits(all_commits, args.samples);
@@ -386,6 +397,7 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
     // dropped as each closure returns, so we never hold all blame output in memory.
     let (blob_hists, hits) = run_blame_phase(
         &blame_lookup, &repo_path, args.no_cache, &cache, &blame_pool, &pb, yearly,
+        ignore_revs_file.as_deref(),
     );
 
     pb.finish_and_clear();

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,11 +205,15 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
                         None
                     }
                     .unwrap_or_else(|| {
-                        spawn_blame(&repo_path, *commit_oid, file_path)
+                        let lines = spawn_blame(&repo_path, *commit_oid, file_path)
                             .and_then(|child| child.wait_with_output().ok())
                             .filter(|o| o.status.success())
-                            .map(|o| parse_blame_output(&o.stdout, blob_oid, &cache))
-                            .unwrap_or_default()
+                            .map(|o| parse_blame_output(&o.stdout))
+                            .unwrap_or_default();
+                        if let Ok(encoded) = bincode::serialize(&lines) {
+                            let _ = cache.insert(blob_oid.as_bytes(), encoded.as_slice());
+                        }
+                        lines
                     });
                     pb.inc(1);
                     let mut period_hist: FxHashMap<i32, u64> = FxHashMap::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,21 @@ struct Cli {
     command: Command,
 }
 
+#[derive(clap::ValueEnum, Debug, Clone, PartialEq)]
+enum Granularity {
+    Quarter,
+    Year,
+}
+
+impl std::fmt::Display for Granularity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Granularity::Quarter => write!(f, "quarter"),
+            Granularity::Year => write!(f, "year"),
+        }
+    }
+}
+
 #[derive(Subcommand, Debug)]
 enum Command {
     /// Analyze repositories and write data files
@@ -52,7 +67,7 @@ struct ProcessArgs {
     extensions: Option<String>,
 
     #[arg(short = 'g', long, default_value = "quarter", help = "Granularity: quarter or year")]
-    granularity: String,
+    granularity: Granularity,
 
     #[arg(short = 'o', long, default_value = "web/data", help = "Output directory for data files")]
     output_dir: PathBuf,
@@ -176,7 +191,7 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
 
     let no_cache = args.no_cache;
     let cache_hits = std::sync::atomic::AtomicU64::new(0);
-    let yearly = args.granularity == "year";
+    let yearly = args.granularity == Granularity::Year;
 
     // Dedicated rayon pool sized for subprocess-bound work (not CPU-bound),
     // so we can saturate I/O without starving the global pool.
@@ -367,7 +382,7 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
 
     let output = OutputData {
         repo: name.clone(),
-        granularity: args.granularity,
+        granularity: args.granularity.to_string(),
         generated_at: chrono::Utc::now().to_rfc3339(),
         head_commit,
         periods: all_periods,

--- a/src/period.rs
+++ b/src/period.rs
@@ -3,6 +3,7 @@ use chrono::{Datelike, TimeZone, Utc};
 use git2::{Oid, Repository};
 use regex::Regex;
 use std::path::Path;
+use std::sync::OnceLock;
 use tracing::debug;
 
 use crate::types::Tag;
@@ -33,9 +34,13 @@ pub fn period_int_to_string(p: i32, yearly: bool) -> String {
     }
 }
 
+static SEMVER_RE: OnceLock<Regex> = OnceLock::new();
+
 pub fn get_version_tags(repo_path: &Path) -> Result<Vec<Tag>> {
     let repo = Repository::open(repo_path)?;
-    let semver_re = Regex::new(r"(?i)^refs/tags/v?(\d+)\.(\d+)\.(\d+)")?;
+    let semver_re = SEMVER_RE.get_or_init(|| {
+        Regex::new(r"(?i)^refs/tags/v?(\d+)\.(\d+)\.(\d+)").unwrap()
+    });
 
     let mut tag_refs: Vec<(String, Oid)> = Vec::new();
     repo.tag_foreach(|oid, name_bytes| {

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -22,7 +22,7 @@ pub fn repo_name(url: &str) -> String {
     url.trim_end_matches('/')
         .trim_end_matches(".git")
         .split('/')
-        .last()
+        .next_back()
         .unwrap_or("repo")
         .to_string()
 }
@@ -143,6 +143,7 @@ pub fn sample_commits(commits: Vec<(Oid, i64)>, n: usize) -> Vec<(Oid, i64)> {
 /// Returns all `(commit_oid, blob_oid)` work pairs **and** a deduplicated
 /// `blame_lookup` map: one `(commit_oid, file_path)` per unique blob OID,
 /// sufficient for the blame phase without duplicating paths across commits.
+#[allow(clippy::type_complexity)]
 pub fn collect_work_items(
     repo_path: &Path,
     sampled: &[(Oid, i64)],
@@ -169,7 +170,7 @@ pub fn collect_work_items(
                 let matched = Path::new(name)
                     .extension()
                     .and_then(|e| e.to_str())
-                    .map(|e| exts.iter().any(|x| x == &format!(".{e}")))
+                    .map(|e| exts.iter().any(|x| x.trim_start_matches('.') == e))
                     .unwrap_or(false);
                 if !matched {
                     return TreeWalkResult::Ok;


### PR DESCRIPTION
## Summary

Internal cleanup and performance improvements — no user-facing behaviour changes except `-w` (ignore whitespace) now being passed to `git blame` by default.

- **`run_process` decomposed** into focused helpers (`collect_work_items`, `run_blame_phase`, `build_blame_pool`, etc.) for readability and testability
- **`Granularity` as a `clap` `ValueEnum`** replacing an ad-hoc string match
- **Blame cache write decoupled** from `parse_blame_output` — cache write is now a caller responsibility, making the parse function pure
- **`-w` passed to `git blame` by default** — whitespace-only changes no longer shift line attribution; bulk formatting commits are bulk-formatted in `.git-blame-ignore-revs` support
- **`OnceLock` for semver regex** in `period.rs` — compiled once instead of per-call
- **Avoid `String` allocation per file** in the extension filter in `repo.rs`