### PR TITLE
perf: speed improvements to collect, blame, and aggregate phases

### DIFF
--- a/src/blame.rs
+++ b/src/blame.rs
@@ -41,8 +41,7 @@ pub fn parse_blame_output(stdout: &[u8]) -> Vec<(i64, String)> {
     // Parse --porcelain: commit metadata appears once per commit, keyed by the 40-char sha
     // that starts each hunk header. "author" and "author-time" lines are cached per sha;
     // "\t" lines emit one (timestamp, author) pair.
-    let mut sha_ts: FxHashMap<[u8; 40], i64> = FxHashMap::default();
-    let mut sha_author: FxHashMap<[u8; 40], String> = FxHashMap::default();
+    let mut sha_meta: FxHashMap<[u8; 40], (i64, String)> = FxHashMap::default();
     let mut current_sha = [0u8; 40];
     let mut current_ts: i64 = 0;
     let mut current_author = String::new();
@@ -52,13 +51,18 @@ pub fn parse_blame_output(stdout: &[u8]) -> Vec<(i64, String)> {
         // Hunk header: "<sha40> <orig> <final> [<count>]"
         if line.len() >= 41 && line[40] == b' ' && line[..40].iter().all(|b| b.is_ascii_hexdigit()) {
             current_sha = line[..40].try_into().unwrap();
-            current_ts = sha_ts.get(&current_sha).copied().unwrap_or(0);
-            current_author = sha_author.get(&current_sha).cloned().unwrap_or_default();
+            if let Some((ts, author)) = sha_meta.get(&current_sha) {
+                current_ts = *ts;
+                current_author = author.clone();
+            } else {
+                current_ts = 0;
+                current_author = String::new();
+            }
         } else if let Some(rest) = line.strip_prefix(b"author ") {
             // "author " (with space) is the blame author name line — distinct from "author-mail", "author-time", etc.
             if let Ok(name) = std::str::from_utf8(rest) {
                 let name = name.trim().to_string();
-                sha_author.insert(current_sha, name.clone());
+                sha_meta.entry(current_sha).or_default().1 = name.clone();
                 current_author = name;
             }
         } else if let Some(rest) = line.strip_prefix(b"author-time ") {
@@ -66,7 +70,7 @@ pub fn parse_blame_output(stdout: &[u8]) -> Vec<(i64, String)> {
                 .ok()
                 .and_then(|s| s.trim().parse().ok())
                 .unwrap_or(0);
-            sha_ts.insert(current_sha, ts);
+            sha_meta.entry(current_sha).or_default().0 = ts;
             current_ts = ts;
         } else if line.starts_with(b"\t") {
             lines.push((current_ts, current_author.clone()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use clap::{Parser, Subcommand};
 use git2::{Oid, Repository};
 use indicatif::{ProgressBar, ProgressStyle};
 use rayon::prelude::*;
-use rustc_hash::{FxHashMap, FxHashSet};
+use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
 use std::fs;
 use std::path::{Path, PathBuf};
 use tracing::{debug, info};
@@ -19,7 +19,7 @@ use tracing_subscriber::{fmt, EnvFilter};
 use blame::{parse_blame_output, spawn_blame};
 use period::{get_version_tags, period_int_to_string, ts_to_period_int};
 use repo::{collect_work_items, ensure_repo, get_commit_list, repo_name, sample_commits};
-use types::{OutputData, SeriesPoint, WorkItem};
+use types::{OutputData, OutputMeta, SeriesPoint, WorkItem};
 
 type BlobHists = FxHashMap<Oid, (FxHashMap<i32, u64>, FxHashMap<String, u64>)>;
 type PeriodAgg = FxHashMap<(Oid, i32), u64>;
@@ -101,6 +101,10 @@ struct ProcessArgs {
     /// Follow only the first-parent chain (skips commits merged from branches)
     #[arg(long = "first-parent")]
     first_parent: bool,
+
+    /// Force recomputation even if output appears current
+    #[arg(long)]
+    force: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -386,20 +390,27 @@ fn write_output(output: &OutputData, output_dir: &Path, name: &str) -> Result<()
     Ok(())
 }
 
-async fn run_process(args: ProcessArgs) -> Result<()> {
+fn compute_run_fingerprint(head_oid: &str, args: &ProcessArgs) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut h = FxHasher::default();
+    head_oid.hash(&mut h);
+    args.samples.hash(&mut h);
+    args.extensions.hash(&mut h);
+    args.include.hash(&mut h);
+    args.exclude.hash(&mut h);
+    args.granularity.to_string().hash(&mut h);
+    args.author_threshold.to_bits().hash(&mut h);
+    args.first_parent.hash(&mut h);
+    format!("{:016x}", h.finish())
+}
 
+async fn run_process(args: ProcessArgs) -> Result<()> {
     #[cfg(feature = "profiling")]
     let _guard = pprof::ProfilerGuardBuilder::default()
         .frequency(1000)
         .blocklist(&["libc", "libgcc", "pthread", "vdso"])
         .build()
         .expect("failed to start profiler");
-
-    let extensions: Option<Vec<String>> = args.extensions.map(|e| {
-        e.split(',').map(|s| s.trim().to_string()).collect()
-    });
-    let include_set = build_glob_set(args.include)?;
-    let exclude_set = build_glob_set(args.exclude)?;
 
     fs::create_dir_all(&args.output_dir)?;
 
@@ -417,8 +428,42 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
         .open()
         .context("Failed to open sled blame cache")?;
 
-    let repo_path = ensure_repo(&args.repo, args.ssh_key)?;
+    // Clone ssh_key so args remains intact for fingerprint computation.
+    let repo_path = ensure_repo(&args.repo, args.ssh_key.clone())?;
     let name = repo_name(&args.repo);
+
+    // Compute HEAD OID early (cheap — no commit walk) for fingerprinting and output.
+    let head_oid = {
+        let r = git2::Repository::open(&repo_path)?;
+        r.head()
+            .ok()
+            .and_then(|h| h.peel_to_commit().ok())
+            .map(|c| c.id().to_string())
+            .unwrap_or_default()
+    };
+
+    let fingerprint = compute_run_fingerprint(&head_oid, &args);
+
+    if !args.force {
+        let out_path = args.output_dir.join(format!("{name}.msgpack"));
+        if let Ok(bytes) = fs::read(&out_path) {
+            if let Ok(meta) = rmp_serde::from_slice::<OutputMeta>(&bytes) {
+                if meta.run_fingerprint.as_deref() == Some(&fingerprint) {
+                    info!(
+                        "Output is current ({}), skipping — use --force to recompute",
+                        name
+                    );
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    let extensions: Option<Vec<String>> = args
+        .extensions
+        .map(|e| e.split(',').map(|s| s.trim().to_string()).collect());
+    let include_set = build_glob_set(args.include)?;
+    let exclude_set = build_glob_set(args.exclude)?;
 
     let ignore_revs_file = {
         let candidate = repo_path.join(".git-blame-ignore-revs");
@@ -516,13 +561,6 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
 
     let tags = get_version_tags(&repo_path).unwrap_or_default();
 
-    let head_commit = repo_for_meta
-        .head()
-        .ok()
-        .and_then(|r| r.peel_to_commit().ok())
-        .map(|c| c.id().to_string())
-        .unwrap_or_default();
-
     let total_lines: u64 = series.last().map(|s| s.total).unwrap_or(0);
     info!("Latest snapshot: {total_lines} total lines across {} periods", all_periods.len());
 
@@ -530,11 +568,12 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
         repo: name.clone(),
         granularity: args.granularity.to_string(),
         generated_at: chrono::Utc::now().to_rfc3339(),
-        head_commit,
+        head_commit: head_oid,
         periods: all_periods,
         authors: all_authors,
         series,
         tags,
+        run_fingerprint: Some(fingerprint),
     };
 
     write_output(&output, &args.output_dir, &name)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,12 +177,14 @@ fn run_blame_phase(
     yearly: bool,
     ignore_revs: Option<&Path>,
 ) -> (BlobHists, u64) {
+    type RawResult = (Oid, (FxHashMap<i32, u64>, FxHashMap<String, u64>), Option<(Vec<u8>, Vec<u8>)>);
+
     let cache_hits = std::sync::atomic::AtomicU64::new(0);
-    let blob_hists = pool.install(|| {
+    let raw: Vec<RawResult> = pool.install(|| {
         blame_lookup
             .par_iter()
             .map(|(&blob_oid, (commit_oid, file_path))| {
-                let lines = if !no_cache {
+                let cached = if !no_cache {
                     cache
                         .get(blob_oid.as_bytes())
                         .ok()
@@ -193,8 +195,11 @@ fn run_blame_phase(
                         })
                 } else {
                     None
-                }
-                .unwrap_or_else(|| {
+                };
+
+                let (lines, write_payload) = if let Some(lines) = cached {
+                    (lines, None)
+                } else {
                     let lines = spawn_blame(repo_path, *commit_oid, file_path, ignore_revs)
                         .and_then(|child| child.wait_with_output().ok())
                         .filter(|o| o.status.success())
@@ -202,13 +207,16 @@ fn run_blame_phase(
                         .unwrap_or_default();
                     // Don't cache empty results — they likely indicate a blame
                     // failure (e.g. bad path, git error) and would poison future runs.
-                    if !lines.is_empty() {
-                        if let Ok(encoded) = bincode::serialize(&lines) {
-                            let _ = cache.insert(blob_oid.as_bytes(), encoded.as_slice());
-                        }
-                    }
-                    lines
-                });
+                    let write_payload = if !lines.is_empty() {
+                        bincode::serialize(&lines)
+                            .ok()
+                            .map(|encoded| (blob_oid.as_bytes().to_vec(), encoded))
+                    } else {
+                        None
+                    };
+                    (lines, write_payload)
+                };
+
                 pb.inc(1);
                 let mut period_hist: FxHashMap<i32, u64> = FxHashMap::default();
                 let mut author_hist: FxHashMap<String, u64> = FxHashMap::default();
@@ -216,11 +224,20 @@ fn run_blame_phase(
                     *period_hist.entry(ts_to_period_int(lts, yearly)).or_insert(0) += 1;
                     *author_hist.entry(author).or_insert(0) += 1;
                 }
-                (blob_oid, (period_hist, author_hist))
+                (blob_oid, (period_hist, author_hist), write_payload)
             })
             .collect()
     });
+
     let hits = cache_hits.load(std::sync::atomic::Ordering::Relaxed);
+    // Apply cache writes sequentially after the parallel phase to eliminate contention.
+    let mut blob_hists = BlobHists::default();
+    for (oid, hists, write) in raw {
+        blob_hists.insert(oid, hists);
+        if let Some((k, v)) = write {
+            let _ = cache.insert(k, v);
+        }
+    }
     (blob_hists, hits)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -483,11 +483,21 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
     let sampled = sample_commits(all_commits, args.samples);
     info!("{} commits sampled", sampled.len());
 
+    let yearly = args.granularity == Granularity::Year;
+    let blame_pool = build_blame_pool(args.jobs)?;
+
     info!("Collecting work items across {} commits", sampled.len());
     // collect_work_items returns compact (commit_oid, blob_oid) pairs plus a
     // deduplicated blame_lookup: one (commit_oid, path) per unique blob.
     // Keeping file_path out of every WorkItem avoids O(commits × files) String allocations.
-    let (items, blame_lookup) = collect_work_items(&repo_path, &sampled, &extensions, &include_set, &exclude_set)?;
+    let (items, blame_lookup) = collect_work_items(
+        &repo_path,
+        &sampled,
+        &extensions,
+        &include_set,
+        &exclude_set,
+        &blame_pool,
+    )?;
     let unique_count = blame_lookup.len();
     let dedup_pct = (1.0 - unique_count as f64 / items.len().max(1) as f64) * 100.0;
     info!(
@@ -501,9 +511,6 @@ async fn run_process(args: ProcessArgs) -> Result<()> {
             .template("  {spinner:.cyan} blaming  [{bar:40.cyan/237}] {pos}/{len}  eta {eta}")?
             .progress_chars("━━╾─"),
     );
-
-    let yearly = args.granularity == Granularity::Year;
-    let blame_pool = build_blame_pool(args.jobs)?;
 
     // Blame each unique blob and aggregate to histograms inline — raw lines are
     // dropped as each closure returns, so we never hold all blame output in memory.

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,18 +242,36 @@ fn run_blame_phase(
 }
 
 fn aggregate(items: &[WorkItem], blob_hists: &BlobHists) -> (PeriodAgg, AuthorAgg) {
-    let mut agg: PeriodAgg = FxHashMap::default();
-    let mut author_agg: AuthorAgg = FxHashMap::default();
-    for item in items {
-        let Some((period_hist, author_hist)) = blob_hists.get(&item.blob_oid) else { continue };
-        for (&period, &count) in period_hist {
-            *agg.entry((item.commit_oid, period)).or_insert(0) += count;
-        }
-        for (author, &count) in author_hist {
-            *author_agg.entry((item.commit_oid, author.clone())).or_insert(0) += count;
-        }
-    }
-    (agg, author_agg)
+    items
+        .par_iter()
+        .filter_map(|item| {
+            let (ph, ah) = blob_hists.get(&item.blob_oid)?;
+            Some((item.commit_oid, ph, ah))
+        })
+        .fold(
+            || (PeriodAgg::default(), AuthorAgg::default()),
+            |(mut agg, mut auth), (oid, ph, ah)| {
+                for (&p, &c) in ph {
+                    *agg.entry((oid, p)).or_insert(0) += c;
+                }
+                for (a, &c) in ah {
+                    *auth.entry((oid, a.clone())).or_insert(0) += c;
+                }
+                (agg, auth)
+            },
+        )
+        .reduce(
+            || (PeriodAgg::default(), AuthorAgg::default()),
+            |(mut a1, mut h1), (a2, h2)| {
+                for (k, v) in a2 {
+                    *a1.entry(k).or_insert(0) += v;
+                }
+                for (k, v) in h2 {
+                    *h1.entry(k).or_insert(0) += v;
+                }
+                (a1, h1)
+            },
+        )
 }
 
 fn select_authors(

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use git2::{Oid, Repository, Sort, TreeWalkMode, TreeWalkResult};
 use globset::GlobSet;
+use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::env;
 use std::fs;
@@ -254,6 +255,9 @@ pub fn sample_commits(commits: Vec<(Oid, i64)>, n: usize) -> Vec<(Oid, i64)> {
 /// Returns all `(commit_oid, blob_oid)` work pairs **and** a deduplicated
 /// `blame_lookup` map: one `(commit_oid, file_path)` per unique blob OID,
 /// sufficient for the blame phase without duplicating paths across commits.
+///
+/// Tree walks are parallelised across commits. Each commit opens its own
+/// `Repository` handle because `git2::Repository` is not `Send`.
 #[allow(clippy::type_complexity)]
 pub fn collect_work_items(
     repo_path: &Path,
@@ -262,56 +266,62 @@ pub fn collect_work_items(
     include_set: &Option<GlobSet>,
     exclude_set: &Option<GlobSet>,
 ) -> Result<(Vec<WorkItem>, FxHashMap<Oid, (Oid, String)>)> {
-    let repo = Repository::open(repo_path)?;
+    // Parallel: each commit opens its own repo handle and returns its matching blobs.
+    let per_commit: Result<Vec<Vec<(Oid, Oid, String)>>> = sampled
+        .par_iter()
+        .map(|&(oid, _)| -> Result<Vec<(Oid, Oid, String)>> {
+            let repo = Repository::open(repo_path)?;
+            let mut entries: Vec<(Oid, Oid, String)> = Vec::new();
+            let commit = repo.find_commit(oid)?;
+            let tree = commit.tree()?;
+
+            tree.walk(TreeWalkMode::PreOrder, |dir, entry| {
+                if entry.kind() != Some(git2::ObjectType::Blob) {
+                    return TreeWalkResult::Ok;
+                }
+                let name = match entry.name() {
+                    Some(n) => n,
+                    None => return TreeWalkResult::Ok,
+                };
+                if let Some(ref exts) = extensions {
+                    let matched = Path::new(name)
+                        .extension()
+                        .and_then(|e| e.to_str())
+                        .map(|e| exts.iter().any(|x| x.trim_start_matches('.') == e))
+                        .unwrap_or(false);
+                    if !matched {
+                        return TreeWalkResult::Ok;
+                    }
+                }
+                let full_path = format!("{dir}{name}");
+                if let Some(ref inc) = include_set {
+                    if !inc.is_match(&full_path) {
+                        return TreeWalkResult::Ok;
+                    }
+                }
+                if let Some(ref exc) = exclude_set {
+                    if exc.is_match(&full_path) {
+                        return TreeWalkResult::Ok;
+                    }
+                }
+                entries.push((entry.id(), oid, full_path));
+                TreeWalkResult::Ok
+            })?;
+
+            trace!("commit {} → {} files", &oid.to_string()[..8], entries.len());
+            Ok(entries)
+        })
+        .collect();
+
+    // Merge sequentially to build items and deduplicated blame_lookup.
     let mut items = Vec::new();
     let mut blame_lookup: FxHashMap<Oid, (Oid, String)> = FxHashMap::default();
-
-    for &(oid, _) in sampled {
-        let before = items.len();
-        let commit = repo.find_commit(oid)?;
-        let tree = commit.tree()?;
-
-        tree.walk(TreeWalkMode::PreOrder, |dir, entry| {
-            if entry.kind() != Some(git2::ObjectType::Blob) {
-                return TreeWalkResult::Ok;
-            }
-            let name = match entry.name() {
-                Some(n) => n,
-                None => return TreeWalkResult::Ok,
-            };
-            if let Some(ref exts) = extensions {
-                let matched = Path::new(name)
-                    .extension()
-                    .and_then(|e| e.to_str())
-                    .map(|e| exts.iter().any(|x| x.trim_start_matches('.') == e))
-                    .unwrap_or(false);
-                if !matched {
-                    return TreeWalkResult::Ok;
-                }
-            }
-            let full_path = format!("{dir}{name}");
-            if let Some(ref inc) = include_set {
-                if !inc.is_match(&full_path) {
-                    return TreeWalkResult::Ok;
-                }
-            }
-            if let Some(ref exc) = exclude_set {
-                if exc.is_match(&full_path) {
-                    return TreeWalkResult::Ok;
-                }
-            }
-            let blob_oid = entry.id();
-            items.push(WorkItem { commit_oid: oid, blob_oid });
+    for commit_entries in per_commit? {
+        for (blob_oid, commit_oid, full_path) in commit_entries {
+            items.push(WorkItem { commit_oid, blob_oid });
             // Store one (commit_oid, path) per unique blob for the blame phase.
-            blame_lookup.entry(blob_oid).or_insert_with(|| (oid, full_path));
-            TreeWalkResult::Ok
-        })?;
-
-        trace!(
-            "commit {} → {} files",
-            &oid.to_string()[..8],
-            items.len() - before
-        );
+            blame_lookup.entry(blob_oid).or_insert_with(|| (commit_oid, full_path));
+        }
     }
 
     debug!("{} (commit, file) work items collected", items.len());

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -3,8 +3,10 @@ use git2::{Oid, Repository, Sort};
 use globset::GlobSet;
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
+use std::cell::RefCell;
 use std::env;
 use std::fs;
+use std::io::{BufRead, BufReader, BufWriter, Read, Write};
 use std::path::{Path, PathBuf};
 use tracing::{debug, info, trace, warn};
 
@@ -252,64 +254,94 @@ pub fn sample_commits(commits: Vec<(Oid, i64)>, n: usize) -> Vec<(Oid, i64)> {
     sampled
 }
 
-/// Parse one line of `git ls-tree -r` output into `(blob_oid, path)`.
-/// Format: `<mode> <type> <sha>\t<path>`
-fn parse_ls_tree_line(line: &[u8]) -> Option<(Oid, String)> {
-    let tab = line.iter().position(|&b| b == b'\t')?;
-    let meta = &line[..tab];
-    let path = std::str::from_utf8(&line[tab + 1..]).ok()?;
-    if path.is_empty() {
-        return None;
-    }
-    // meta = "<mode> <type> <sha>" — find the two spaces
-    let sp1 = meta.iter().position(|&b| b == b' ')?;
-    let sp2 = meta[sp1 + 1..].iter().position(|&b| b == b' ')? + sp1 + 1;
-    if &meta[sp1 + 1..sp2] != b"blob" {
-        return None;
-    }
-    let sha = std::str::from_utf8(&meta[sp2 + 1..]).ok()?;
-    let blob_oid = Oid::from_str(sha).ok()?;
-    Some((blob_oid, path.to_string()))
+/// A persistent `git cat-file --batch` subprocess used to read tree objects
+/// without per-commit spawn overhead. One instance lives per rayon thread via
+/// `thread_local!`, amortising git startup across all commits on that thread.
+struct CatFile {
+    _child: std::process::Child,
+    stdin: BufWriter<std::process::ChildStdin>,
+    stdout: BufReader<std::process::ChildStdout>,
 }
 
-/// Shell out to `git ls-tree -r` to list all blobs in a commit tree.
-/// Same approach as blame: subprocess is orders of magnitude faster than
-/// libgit2's tree walk under parallel load due to ODB lock contention.
-fn ls_tree_blobs(repo_path: &Path, commit_oid: Oid) -> Vec<(Oid, String)> {
-    let output = std::process::Command::new("git")
-        .args([
-            "-C",
-            &repo_path.to_string_lossy(),
-            "ls-tree",
-            "-r",
-            "--full-tree",
-            &commit_oid.to_string(),
-        ])
-        .env("GIT_CONFIG_NOSYSTEM", "1")
-        .env(
-            "GIT_CONFIG_GLOBAL",
-            if cfg!(windows) { "NUL" } else { "/dev/null" },
-        )
-        .env("GIT_OPTIONAL_LOCKS", "0")
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::null())
-        .output()
-        .map(|o| o.stdout)
-        .unwrap_or_default();
+impl CatFile {
+    fn start(repo_path: &Path) -> Option<Self> {
+        let mut child = std::process::Command::new("git")
+            .args(["-C", &repo_path.to_string_lossy(), "cat-file", "--batch"])
+            .env("GIT_CONFIG_NOSYSTEM", "1")
+            .env(
+                "GIT_CONFIG_GLOBAL",
+                if cfg!(windows) { "NUL" } else { "/dev/null" },
+            )
+            .env("GIT_OPTIONAL_LOCKS", "0")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn()
+            .ok()?;
+        let stdin = BufWriter::new(child.stdin.take()?);
+        let stdout = BufReader::new(child.stdout.take()?);
+        Some(Self { _child: child, stdin, stdout })
+    }
 
-    output
-        .split(|&b| b == b'\n')
-        .filter_map(parse_ls_tree_line)
-        .collect()
+    /// Recursively walk a tree object, appending `(blob_oid, path)` to `out`.
+    /// Binary tree format per entry: `<mode> <name>\0<20-byte-sha>`.
+    fn walk_tree(&mut self, tree_oid: Oid, prefix: &str, out: &mut Vec<(Oid, String)>) {
+        if writeln!(self.stdin, "{tree_oid}").is_err() { return; }
+        if self.stdin.flush().is_err() { return; }
+
+        // Header: "<sha> <type> <size>\n"  or  "<sha> missing\n"
+        let mut header = String::new();
+        if self.stdout.read_line(&mut header).is_err() { return; }
+        let mut parts = header.split_ascii_whitespace();
+        parts.next(); // sha
+        let obj_type = parts.next().unwrap_or("");
+        let size: usize = match parts.next().and_then(|s| s.parse().ok()) {
+            Some(n) if obj_type == "tree" => n,
+            _ => return, // missing or not a tree; stream is still clean (no data follows)
+        };
+
+        let mut data = vec![0u8; size];
+        if Read::read_exact(&mut self.stdout, &mut data).is_err() { return; }
+        let mut nl = [0u8; 1];
+        let _ = Read::read_exact(&mut self.stdout, &mut nl); // consume trailing newline
+
+        // Parse entries: "<mode> <name>\0<20-byte-sha>" ...
+        let mut i = 0;
+        while i < data.len() {
+            let Some(sp) = data[i..].iter().position(|&b| b == b' ') else { break };
+            let sp = i + sp;
+            let mode = &data[i..sp];
+
+            let Some(nul) = data[sp + 1..].iter().position(|&b| b == 0) else { break };
+            let nul = sp + 1 + nul;
+            let name = match std::str::from_utf8(&data[sp + 1..nul]) {
+                Ok(n) => n,
+                Err(_) => { i = nul + 21; continue; }
+            };
+            if nul + 21 > data.len() { break; }
+            let entry_oid = match Oid::from_bytes(&data[nul + 1..nul + 21]) {
+                Ok(id) => id,
+                Err(_) => { i = nul + 21; continue; }
+            };
+            i = nul + 21;
+
+            if mode == b"40000" || mode == b"040000" {
+                self.walk_tree(entry_oid, &format!("{prefix}{name}/"), out);
+            } else if mode != b"160000" {
+                // blob (100644 / 100755 / 120000); skip gitlinks (160000)
+                out.push((entry_oid, format!("{prefix}{name}")));
+            }
+        }
+    }
 }
 
 /// Returns all `(commit_oid, blob_oid)` work pairs **and** a deduplicated
 /// `blame_lookup` map: one `(commit_oid, file_path)` per unique blob OID,
 /// sufficient for the blame phase without duplicating paths across commits.
 ///
-/// Uses `git ls-tree` subprocesses (not libgit2) to avoid ODB lock contention
-/// under parallel load. Runs inside `pool` so `-j` applies to both this phase
-/// and the subsequent blame phase.
+/// Uses one persistent `git cat-file --batch` process per rayon thread so
+/// git startup cost is paid once per thread, not once per commit. Runs inside
+/// `pool` so `-j` controls parallelism for both this phase and blame.
 #[allow(clippy::type_complexity)]
 pub fn collect_work_items(
     repo_path: &Path,
@@ -319,38 +351,59 @@ pub fn collect_work_items(
     exclude_set: &Option<GlobSet>,
     pool: &rayon::ThreadPool,
 ) -> Result<(Vec<WorkItem>, FxHashMap<Oid, (Oid, String)>)> {
-    let per_commit: Vec<Vec<(Oid, Oid, String)>> = pool.install(|| {
+    // Single-threaded: resolve tree OID for each commit (reads only the commit
+    // object — a few hundred bytes — so this is very fast).
+    let commit_trees: Vec<(Oid, Oid)> = {
+        let repo = Repository::open(repo_path)?;
         sampled
+            .iter()
+            .filter_map(|&(oid, _)| Some((oid, repo.find_commit(oid).ok()?.tree_id())))
+            .collect()
+    };
+
+    thread_local! {
+        static CAT_FILE: RefCell<Option<CatFile>> = RefCell::new(None);
+    }
+
+    let per_commit: Vec<Vec<(Oid, Oid, String)>> = pool.install(|| {
+        commit_trees
             .par_iter()
-            .map(|&(oid, _)| {
-                let entries: Vec<(Oid, Oid, String)> = ls_tree_blobs(repo_path, oid)
-                    .into_iter()
-                    .filter(|(_, path)| {
-                        if let Some(ref exts) = extensions {
-                            let ext = Path::new(path)
-                                .extension()
-                                .and_then(|e| e.to_str())
-                                .unwrap_or("");
-                            if !exts.iter().any(|x| x.trim_start_matches('.') == ext) {
-                                return false;
+            .map(|&(commit_oid, tree_oid)| {
+                CAT_FILE.with(|cell| {
+                    let mut opt = cell.borrow_mut();
+                    if opt.is_none() {
+                        *opt = CatFile::start(repo_path);
+                    }
+                    let Some(cat_file) = opt.as_mut() else { return vec![] };
+
+                    let mut blobs = Vec::new();
+                    cat_file.walk_tree(tree_oid, "", &mut blobs);
+
+                    let entries = blobs
+                        .into_iter()
+                        .filter(|(_, path)| {
+                            if let Some(ref exts) = extensions {
+                                let ext = Path::new(path)
+                                    .extension()
+                                    .and_then(|e| e.to_str())
+                                    .unwrap_or("");
+                                if !exts.iter().any(|x| x.trim_start_matches('.') == ext) {
+                                    return false;
+                                }
                             }
-                        }
-                        if let Some(ref inc) = include_set {
-                            if !inc.is_match(path) {
-                                return false;
+                            if let Some(ref inc) = include_set {
+                                if !inc.is_match(path) { return false; }
                             }
-                        }
-                        if let Some(ref exc) = exclude_set {
-                            if exc.is_match(path) {
-                                return false;
+                            if let Some(ref exc) = exclude_set {
+                                if exc.is_match(path) { return false; }
                             }
-                        }
-                        true
-                    })
-                    .map(|(blob_oid, path)| (blob_oid, oid, path))
-                    .collect();
-                trace!("commit {} → {} files", &oid.to_string()[..8], entries.len());
-                entries
+                            true
+                        })
+                        .map(|(blob_oid, path)| (blob_oid, commit_oid, path))
+                        .collect::<Vec<_>>();
+                    trace!("commit {} → {} files", &commit_oid.to_string()[..8], entries.len());
+                    entries
+                })
             })
             .collect()
     });
@@ -361,7 +414,6 @@ pub fn collect_work_items(
     for commit_entries in per_commit {
         for (blob_oid, commit_oid, path) in commit_entries {
             items.push(WorkItem { commit_oid, blob_oid });
-            // Store one (commit_oid, path) per unique blob for the blame phase.
             blame_lookup.entry(blob_oid).or_insert_with(|| (commit_oid, path));
         }
     }

--- a/src/repo.rs
+++ b/src/repo.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use git2::{Oid, Repository, Sort, TreeWalkMode, TreeWalkResult};
+use git2::{Oid, Repository, Sort};
 use globset::GlobSet;
 use rayon::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -252,12 +252,64 @@ pub fn sample_commits(commits: Vec<(Oid, i64)>, n: usize) -> Vec<(Oid, i64)> {
     sampled
 }
 
+/// Parse one line of `git ls-tree -r` output into `(blob_oid, path)`.
+/// Format: `<mode> <type> <sha>\t<path>`
+fn parse_ls_tree_line(line: &[u8]) -> Option<(Oid, String)> {
+    let tab = line.iter().position(|&b| b == b'\t')?;
+    let meta = &line[..tab];
+    let path = std::str::from_utf8(&line[tab + 1..]).ok()?;
+    if path.is_empty() {
+        return None;
+    }
+    // meta = "<mode> <type> <sha>" — find the two spaces
+    let sp1 = meta.iter().position(|&b| b == b' ')?;
+    let sp2 = meta[sp1 + 1..].iter().position(|&b| b == b' ')? + sp1 + 1;
+    if &meta[sp1 + 1..sp2] != b"blob" {
+        return None;
+    }
+    let sha = std::str::from_utf8(&meta[sp2 + 1..]).ok()?;
+    let blob_oid = Oid::from_str(sha).ok()?;
+    Some((blob_oid, path.to_string()))
+}
+
+/// Shell out to `git ls-tree -r` to list all blobs in a commit tree.
+/// Same approach as blame: subprocess is orders of magnitude faster than
+/// libgit2's tree walk under parallel load due to ODB lock contention.
+fn ls_tree_blobs(repo_path: &Path, commit_oid: Oid) -> Vec<(Oid, String)> {
+    let output = std::process::Command::new("git")
+        .args([
+            "-C",
+            &repo_path.to_string_lossy(),
+            "ls-tree",
+            "-r",
+            "--full-tree",
+            &commit_oid.to_string(),
+        ])
+        .env("GIT_CONFIG_NOSYSTEM", "1")
+        .env(
+            "GIT_CONFIG_GLOBAL",
+            if cfg!(windows) { "NUL" } else { "/dev/null" },
+        )
+        .env("GIT_OPTIONAL_LOCKS", "0")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .map(|o| o.stdout)
+        .unwrap_or_default();
+
+    output
+        .split(|&b| b == b'\n')
+        .filter_map(parse_ls_tree_line)
+        .collect()
+}
+
 /// Returns all `(commit_oid, blob_oid)` work pairs **and** a deduplicated
 /// `blame_lookup` map: one `(commit_oid, file_path)` per unique blob OID,
 /// sufficient for the blame phase without duplicating paths across commits.
 ///
-/// Tree walks are parallelised across commits. Each commit opens its own
-/// `Repository` handle because `git2::Repository` is not `Send`.
+/// Uses `git ls-tree` subprocesses (not libgit2) to avoid ODB lock contention
+/// under parallel load. Runs inside `pool` so `-j` applies to both this phase
+/// and the subsequent blame phase.
 #[allow(clippy::type_complexity)]
 pub fn collect_work_items(
     repo_path: &Path,
@@ -265,62 +317,52 @@ pub fn collect_work_items(
     extensions: &Option<Vec<String>>,
     include_set: &Option<GlobSet>,
     exclude_set: &Option<GlobSet>,
+    pool: &rayon::ThreadPool,
 ) -> Result<(Vec<WorkItem>, FxHashMap<Oid, (Oid, String)>)> {
-    // Parallel: each commit opens its own repo handle and returns its matching blobs.
-    let per_commit: Result<Vec<Vec<(Oid, Oid, String)>>> = sampled
-        .par_iter()
-        .map(|&(oid, _)| -> Result<Vec<(Oid, Oid, String)>> {
-            let repo = Repository::open(repo_path)?;
-            let mut entries: Vec<(Oid, Oid, String)> = Vec::new();
-            let commit = repo.find_commit(oid)?;
-            let tree = commit.tree()?;
-
-            tree.walk(TreeWalkMode::PreOrder, |dir, entry| {
-                if entry.kind() != Some(git2::ObjectType::Blob) {
-                    return TreeWalkResult::Ok;
-                }
-                let name = match entry.name() {
-                    Some(n) => n,
-                    None => return TreeWalkResult::Ok,
-                };
-                if let Some(ref exts) = extensions {
-                    let matched = Path::new(name)
-                        .extension()
-                        .and_then(|e| e.to_str())
-                        .map(|e| exts.iter().any(|x| x.trim_start_matches('.') == e))
-                        .unwrap_or(false);
-                    if !matched {
-                        return TreeWalkResult::Ok;
-                    }
-                }
-                let full_path = format!("{dir}{name}");
-                if let Some(ref inc) = include_set {
-                    if !inc.is_match(&full_path) {
-                        return TreeWalkResult::Ok;
-                    }
-                }
-                if let Some(ref exc) = exclude_set {
-                    if exc.is_match(&full_path) {
-                        return TreeWalkResult::Ok;
-                    }
-                }
-                entries.push((entry.id(), oid, full_path));
-                TreeWalkResult::Ok
-            })?;
-
-            trace!("commit {} → {} files", &oid.to_string()[..8], entries.len());
-            Ok(entries)
-        })
-        .collect();
+    let per_commit: Vec<Vec<(Oid, Oid, String)>> = pool.install(|| {
+        sampled
+            .par_iter()
+            .map(|&(oid, _)| {
+                let entries: Vec<(Oid, Oid, String)> = ls_tree_blobs(repo_path, oid)
+                    .into_iter()
+                    .filter(|(_, path)| {
+                        if let Some(ref exts) = extensions {
+                            let ext = Path::new(path)
+                                .extension()
+                                .and_then(|e| e.to_str())
+                                .unwrap_or("");
+                            if !exts.iter().any(|x| x.trim_start_matches('.') == ext) {
+                                return false;
+                            }
+                        }
+                        if let Some(ref inc) = include_set {
+                            if !inc.is_match(path) {
+                                return false;
+                            }
+                        }
+                        if let Some(ref exc) = exclude_set {
+                            if exc.is_match(path) {
+                                return false;
+                            }
+                        }
+                        true
+                    })
+                    .map(|(blob_oid, path)| (blob_oid, oid, path))
+                    .collect();
+                trace!("commit {} → {} files", &oid.to_string()[..8], entries.len());
+                entries
+            })
+            .collect()
+    });
 
     // Merge sequentially to build items and deduplicated blame_lookup.
     let mut items = Vec::new();
     let mut blame_lookup: FxHashMap<Oid, (Oid, String)> = FxHashMap::default();
-    for commit_entries in per_commit? {
-        for (blob_oid, commit_oid, full_path) in commit_entries {
+    for commit_entries in per_commit {
+        for (blob_oid, commit_oid, path) in commit_entries {
             items.push(WorkItem { commit_oid, blob_oid });
             // Store one (commit_oid, path) per unique blob for the blame phase.
-            blame_lookup.entry(blob_oid).or_insert_with(|| (commit_oid, full_path));
+            blame_lookup.entry(blob_oid).or_insert_with(|| (commit_oid, path));
         }
     }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 use git2::Oid;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize)]
 pub struct OutputData {
@@ -11,6 +11,15 @@ pub struct OutputData {
     pub authors: Vec<String>,
     pub series: Vec<SeriesPoint>,
     pub tags: Vec<Tag>,
+    pub run_fingerprint: Option<String>,
+}
+
+/// Minimal deserializable view of an existing output file, for incremental-skip checks.
+/// Unknown fields are silently skipped, so old files without `run_fingerprint` still parse.
+#[derive(Deserialize)]
+pub struct OutputMeta {
+    #[serde(default)]
+    pub run_fingerprint: Option<String>,
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
## Summary

- **Parallelise `collect_work_items` tree walks** across commits using Rayon, reducing single-threaded bottleneck for large repos
- **Replace libgit2 tree walk with `git ls-tree` subprocesses** — faster and more consistent with the existing subprocess-based blame strategy
- **Replace per-commit `ls-tree` with thread-local `cat-file --batch`** — reuses a single long-running process per thread, eliminating repeated subprocess startup costs
- **Parallelise `aggregate()`** with Rayon fold/reduce for faster line-count aggregation
- **Batch sled cache writes** after the parallel blame phase instead of per-blame, reducing write amplification
- **Merge `sha_ts` and `sha_author` maps** into a single `sha_meta` map to halve hash lookups in hot blame parsing path
- **Skip recomputation when output fingerprint matches** — avoid re-running blame entirely when the input hasn't changed